### PR TITLE
Revert "Añadir la web de go by example"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@
 
 ## Menciones honoríficas en otros idiomas
   * [awesome-go (inglés)](https://github.com/avelino/awesome-go) - Es la lista definitiva de packages, y frameworks de go mantenida por la comunidad internacional. Antes de crear un package, fíjate si existe en esta lista y si te sirven sus prestaciones y API. Como último recurso, siempre está la [búsqueda avanzada](https://github.com/search/advanced) de Github
-  * [GoByExample (Inglés)](https://gobyexample.com/) - Un ejemplo como crear algo en go con un ejemplo de los mejores sitios de los cuales yo he visto que explican sobre go.
 
 ### 🗒️ Blogs
   * [charly3pins](https://charly3pins.dev/es/) - Blog de Go y tutoriales de [Carles Fuste](https://github.com/charly3pins)


### PR DESCRIPTION
Observando, eso se encuentra ya desde **[github.com/gophers-latam/awesome-latam#-miscelaneos](https://github.com/gophers-latam/awesome-latam#-miscelaneos)** en **[github.com/gophers-mx/recursos](https://github.com/gophers-mx/recursos)** que previamente se habian compartido y propuesto ahi a como se dejo en post **[wp.me/p1baRR-Hc](https://wp.me/p1baRR-Hc)** por lo cual para no ser redundante se revierte el cambio. Disculpas @TeoDev1611 algo asi se trato inicialmente aqui **[github.com/gophers-latam/awesome-latam/pull/1](https://github.com/gophers-latam/awesome-latam/pull/1)**