### PR TITLE
Se agregan portales de empleos dedicados a Golang

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     - 🗒️ [Blogs](#%EF%B8%8F-blogs)
     - 📺 [Videos y canales](#-videos-y-canales)
     - 👨‍🏫 [Charlas y presentaciones](#-charlas-y-presentaciones)
+    - 💼 [Portales de empleos](#-portales-de-empleos)
 
 - 📦 [Recursos](#-recursos)
     - 🏁 [Benchmarks](#-benchmarks)
@@ -29,6 +30,7 @@
 **Sitios dedicados al desarrollo en Go o desarrollo en general pero con foco en Golang**
 
 ## ⭐ Menciones honoríficas en otros idiomas
+
   * [go tour (Inglés)](https://tour.golang.org/list) - Tour base oficial del lenguaje, para familizarse con los conceptos base y tsintaxis
   * [go-proverbs (Inglés)](https://go-proverbs.github.io/) - Lineamientos de desarrollo y buenas practicas dados en forma de proverbios por Rob Pike en 2015
   * [effective go (Inglés)](https://golang.org/doc/effective_go) - Lineamientos y recomiendaciones de desarrollo oficiales de la documentación de Go
@@ -36,6 +38,7 @@
 
 
 ### 🗒️ Blogs
+
   * [charly3pins](https://charly3pins.dev/es/) - Blog de Go y tutoriales de [Carles Fuste](https://github.com/charly3pins)
 
   * [c0d3.mx](https://umarquez.c0d3.mx/posts) - Blog con tutoriales de Go por [Uriel Márquez](https://github.com/umarquez)
@@ -43,6 +46,7 @@
   * [friendsofgo](https://blog.friendsofgo.tech/) - Blog con articulos tecnicos por [Adrian Perez](https://github.com/aperezg) , [Joan Lopez De La Franca](https://github.com/joanlopez)
 
 ### 📺 Videos y canales
+
   * [Golandia](https://www.youtube.com/c/Golandia) - Canal de youtube con tutoriales y discusiones acerca de Go y packages
 
   * [tomas lingotti](https://www.youtube.com/c/tomaslingotti) - Canal de videos sobre el lenguaje Golang, microservicios, tecnologías y mas, todo en español, hecho desde Argentina.
@@ -50,9 +54,20 @@
   * [Alexys Lozada](https://www.youtube.com/c/Alexyslozada) - Canal de la comunidad Golang de Alexys Lozada.
 
 ### 👨‍🏫 Charlas y presentaciones
+
   * [go-talks](https://github.com/lggomez/go-talks) - Repositorio de charlas y presentaciones sobre Go por [Luis Gomez](https://github.com/lggomez)
 
   * [Golang Guadalajara](https://www.youtube.com/channel/UCxpBz-Hw1p5S-v3vPpwi5oA) - Lives en FB y YT de [Golang Guadalajara](https://www.facebook.com/golang.guadalajara/)
+
+### 💼 Portales de empleos
+
+  * [Golang News jobs](https://golangnews.com/go-jobs)
+
+  * [Golang Cafe](https://golang.cafe/)
+
+  * [We Love Golang](https://welovegolang.com/)
+
+  * [Work with Go](https://workwithgo.com/)
 
 ## 📦 Recursos
 


### PR DESCRIPTION
Se propone agregar sitios de portales de empleos dedicados a Golang. Alternativamente estos se han dejado en la descripción del canal **🤑ofertas-trabajo** del Discord 
![captura](https://user-images.githubusercontent.com/2924638/116486815-18b27580-a854-11eb-8d5b-a739b42ae961.png)
